### PR TITLE
[feat] 기본적인 DB 테이블 설계 (#7)

### DIFF
--- a/src/main/java/com/skt5cean/cheerup/company/domain/Bookmark.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Bookmark.java
@@ -1,0 +1,30 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Company company;
+
+    private String link;
+
+    public static Bookmark createBookmark(Company company, String link){
+        Bookmark bookmark = new Bookmark();
+        bookmark.company = company;
+        bookmark.link = link;
+        return bookmark;
+    }
+
+    public void update(String link){
+        this.link = link;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Company.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Company.java
@@ -1,0 +1,64 @@
+package com.skt5cean.cheerup.company.domain;
+
+import com.skt5cean.cheerup.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    // 자소서의 질문 - 답변
+    @OneToMany(mappedBy = "company", cascade = CascadeType.REMOVE)
+    private List<Resume> resumes = new ArrayList<>();
+
+    // 관련 링크
+    @OneToMany(mappedBy = "company", cascade = CascadeType.REMOVE)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
+    // 해당 기업의 전형
+    @OneToMany(mappedBy = "company", cascade = CascadeType.REMOVE)
+    private List<Step> steps = new ArrayList<>();
+
+    // 회사명
+    @Column(nullable = false)
+    private String companyName;
+
+    // 인재상
+    private String talent;
+
+    // 기업 제품
+    private String product;
+
+    // 최신 뉴스
+    private String news;
+
+    // 기타
+    private String other;
+
+    public static Company createCompany(String companyName, List<Step> steps, User user){
+        Company company = new Company();
+        company.companyName = companyName;
+        company.steps = steps;
+        company.user = user;
+        return company;
+    }
+
+    public void updateCompanyInfo(String talent, String product, String news, String other){
+        this.talent = talent;
+        this.product = product;
+        this.news = news;
+        this.other = other;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Document.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Document.java
@@ -1,0 +1,18 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+
+/**
+ * 중복되는 질문-답변 필드를 부모 클래스 Document로 관리하고, 상속하여 처리
+ */
+@Getter
+public class Document {
+
+    // 질문(제목) - 반드시 존재해야 함
+    @Column(nullable = false)
+    protected String title;
+
+    // 내용
+    protected String contents;
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Recap.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Recap.java
@@ -1,0 +1,25 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Recap extends Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recap_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Step step;
+
+    public static Recap createRecap(Step step, String title, String contents){
+        Recap recap = new Recap();
+        recap.step = step;
+        recap.title = title;
+        recap.contents = contents;
+        return recap;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Resume.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Resume.java
@@ -1,0 +1,29 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Resume extends Document{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Company company;
+
+    public static Resume createResume(Company company, String title){
+        Resume resume = new Resume();
+        resume.company = company;
+        resume.title = title;
+        return resume;
+    }
+
+    public void update(String title, String contents){
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Review.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Review.java
@@ -1,0 +1,24 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Review extends Document{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Step step;
+
+    public static Review createReview(Step step, String contents){
+        Review review = new Review();
+        review.step = step;
+        review.contents = contents;
+        return review;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/company/domain/Step.java
+++ b/src/main/java/com/skt5cean/cheerup/company/domain/Step.java
@@ -1,0 +1,40 @@
+package com.skt5cean.cheerup.company.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Step {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "step_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Company company;
+
+    @OneToMany(mappedBy = "step", cascade = CascadeType.REMOVE)
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "step", cascade = CascadeType.REMOVE)
+    private List<Recap> recaps = new ArrayList<>();
+
+    // 전형명(서류전형, 기술면접 등)
+    private String stepName;
+
+    // 전형 탈락 여부
+    private Boolean isFailed;
+
+    public static Step createStep(Company company, String stepName){
+        Step step = new Step();
+        step.company = company;
+        step.stepName = stepName;
+        step.isFailed = false;
+        return step;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/user/domain/TotalDocument.java
+++ b/src/main/java/com/skt5cean/cheerup/user/domain/TotalDocument.java
@@ -1,0 +1,30 @@
+package com.skt5cean.cheerup.user.domain;
+
+import com.skt5cean.cheerup.company.domain.Document;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class TotalDocument extends Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "total_document_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    public static TotalDocument createTotalDocument(User user, String title, String contents){
+        TotalDocument totalDocument = new TotalDocument();
+        totalDocument.user = user;
+        totalDocument.title = title;
+        totalDocument.contents = contents;
+        return totalDocument;
+    }
+
+    public void update(String contents){
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/user/domain/TotalInterview.java
+++ b/src/main/java/com/skt5cean/cheerup/user/domain/TotalInterview.java
@@ -1,0 +1,30 @@
+package com.skt5cean.cheerup.user.domain;
+
+import com.skt5cean.cheerup.company.domain.Document;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class TotalInterview extends Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "total_interview_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    public static TotalInterview createTotalInterview(User user, String title, String contents){
+        TotalInterview totalInterview = new TotalInterview();
+        totalInterview.user = user;
+        totalInterview.title = title;
+        totalInterview.contents = contents;
+        return totalInterview;
+    }
+
+    public void update(String contents){
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/skt5cean/cheerup/user/domain/User.java
+++ b/src/main/java/com/skt5cean/cheerup/user/domain/User.java
@@ -43,6 +43,9 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     List<TotalDocument> totalDocuments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    List<TotalInterview> totalInterviews = new ArrayList<>();
+
     public static User createUser(String nickname, Long kakaoId) {
         User user = new User();
         user.nickname = nickname;

--- a/src/main/java/com/skt5cean/cheerup/user/domain/User.java
+++ b/src/main/java/com/skt5cean/cheerup/user/domain/User.java
@@ -1,7 +1,9 @@
 package com.skt5cean.cheerup.user.domain;
 
+import com.skt5cean.cheerup.company.domain.Company;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -26,11 +28,32 @@ public class User implements UserDetails {
 
     private String nickname;
 
+    @Setter
+    private String goal;
+
+    private String keyword1;
+
+    private String keyword2;
+
+    private String keyword3;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    List<Company> companies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    List<TotalDocument> totalDocuments = new ArrayList<>();
+
     public static User createUser(String nickname, Long kakaoId) {
         User user = new User();
         user.nickname = nickname;
         user.kakaoId = kakaoId;
         return user;
+    }
+
+    public void updateKeywords(String keyword1, String keyword2, String keyword3){
+        this.keyword1 = keyword1;
+        this.keyword2 = keyword2;
+        this.keyword3 = keyword3;
     }
 
     //Jwt 설정을 위한 UserDetails 메소드


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #7

# 📝 작업 내용

> 기본적인 DB 테이블을 설계했습니다.
> 한편, 각 Entity마다 반복되는 title-contents 필드의 중복을 최소화하기 위해 부모 클래스 Document를 도입하였습니다.
> 이를 상속하는 형태로 Entity를 구성하였습니다.

## 참고 이미지 및 자료


# 💬 리뷰 요구사항

> 혹시나 누락된 필드 같은 게 있는지 검토 부탁드립니다!